### PR TITLE
文法チェックルールで、リスト内の"ですます"を許容する

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -4,7 +4,7 @@
         "no-mix-dearu-desumasu": {
           "preferInHeader": "",
           "preferInBody": "ですます",
-          "preferInList": "である",
+          "preferInList": "",
           "strict": false
         },
         "ja-no-weak-phrase": true,


### PR DESCRIPTION
https://github.com/geolonia/handbook.geolonia.com/pull/36 で以下のスクリーンショットのように、ですますが許容されなかった。

![スクリーンショット 2025-01-20 18 03 33](https://github.com/user-attachments/assets/8f5b31e3-a1c7-426d-88a8-c4eced8ca2e7)
