### PR TITLE
Fix duplicate recommend plugin section

### DIFF
--- a/docs/組織別/開発/recommend-plugin.md
+++ b/docs/組織別/開発/recommend-plugin.md
@@ -52,38 +52,3 @@ Chrome拡張機能のインストールは以下の手順で行います：
 | **AI支援** | GitHub Copilot | AIによるコード補完 |
 |  | GitHub Copilot Chat | AIとの対話型開発支援 |
 | **バージョン管理** | Git History | Gitの履歴管理・可視化 |
-
-
-## GoogleChrome 拡張機能
-
-### インストール手順
-
-拡張機能のインストールは以下の手順で行います：
-
-1. VS Codeを開きます
-2. `Ctrl+Shift+X`（Mac: `Cmd+Shift+X`）を押して拡張機能パネルを開きます
-3. 上記の拡張機能IDを検索します
-4. 「Install」をクリックしてインストールします
-
-### 拡張機能一覧
-
-| カテゴリ | 拡張機能 | 主な用途 |
-|---------|----------|----------|
-| **API開発** | OpenAPI (Swagger) Editor | APIの設計・開発をサポート |
-|  | Swagger Viewer | APIドキュメントのプレビュー |
-|  | Swagger Tools | Swaggerファイルの管理 |
-| **コード品質管理** | Prettier | コードフォーマットの自動化 |
-|  | EditorConfig | コーディングスタイルの統一 |
-|  | Trailing Spaces | 不要な空白の検出・削除 |
-|  | Better Comments | コメントの視認性向上 |
-|  | indent-rainbow | インデントの可視化 |
-| **図表作成** | Draw.io Integration | 汎用的な図表作成 |
-|  | PlantUML | UML図の作成 |
-|  | Markdown Mermaid | Markdownでの図表表現 |
-| **開発環境** | Docker | コンテナ環境の管理 |
-|  | Remote Containers | コンテナでの開発環境 |
-|  | Live Server | 開発用ローカルサーバー |
-|  | Path Intellisense | ファイルパスの入力補完 |
-| **AI支援** | GitHub Copilot | AIによるコード補完 |
-|  | GitHub Copilot Chat | AIとの対話型開発支援 |
-| **バージョン管理** | Git History | Gitの履歴管理・可視化 |


### PR DESCRIPTION
`組織別`/`開発`/`推奨拡張機能・ツール` で、 `VS Code 拡張機能` に続けて `GoogleChrome 拡張機能` が同じ内容で重複して記載されていましたので、重複分を削除する対応を行いました。

念のため、手元でバックアップした各セクションと、diffの結果(違いはタイトルのみ)も載せておきます。

- [vs-code-extension.md](https://github.com/user-attachments/files/20681206/vs-code-extension.md)
- [chrome-extension.md](https://github.com/user-attachments/files/20681207/chrome-extension.md)

```sh
diff -u vs-code-extension.md chrome-extension.md
```
```diff
--- vs-code-extension.md	2025-06-11 08:16:06
+++ chrome-extension.md	2025-06-11 08:16:24
@@ -1,4 +1,4 @@
-## VS Code 拡張機能
+## GoogleChrome 拡張機能
 
 ### インストール手順
 
```